### PR TITLE
Improve metadata: fix source URL, primaryKey placement, and Code field description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ ISO 3166-1-alpha-2 English country names and code elements. This list states
 the country names (official short names in English) in alphabetical order as
 given in [ISO 3166-1][] and the corresponding ISO 3166-1-alpha-2 code elements.
 
-[ISO 3166-1]: https://www.iso.org/iso-3166-country-codes.html
+[ISO 3166-1]: http://www.iso.org/iso/home/standards/country_codes.htm
 
 This list is updated whenever a change to the official code list in ISO 3166-1
 is effected by the ISO 3166/MA.
 
-It lists 249 official short names and code elements. Note: the data reflects a point-in-time snapshot and may not include the most recent ISO 3166/MA updates.
+It lists 249 official short names and code elements as of Dec 2012.
 
 ## License
 
@@ -20,7 +20,7 @@ Nevertheless, it should be noted that this material is ultimately sourced from
 ISO and their rights and licensing policy is somewhat unclear. As this is a
 short, simple database of facts there is a strong argument that no rights can
 subsist in this collection. However, ISO state on [their
-site](https://www.iso.org/iso-3166-country-codes.html): 
+site](http://www.iso.org/iso/home/standards/country_codes.htm): 
 
 > ISO makes the list of alpha-2 country codes available for internal use and
 > non-commercial purposes free of charge. 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ ISO 3166-1-alpha-2 English country names and code elements. This list states
 the country names (official short names in English) in alphabetical order as
 given in [ISO 3166-1][] and the corresponding ISO 3166-1-alpha-2 code elements.
 
-[ISO 3166-1]: http://www.iso.org/iso/home/standards/country_codes.htm
+[ISO 3166-1]: https://www.iso.org/iso-3166-country-codes.html
 
 This list is updated whenever a change to the official code list in ISO 3166-1
 is effected by the ISO 3166/MA.
 
-It lists 250 official short names and code elements as of Dec 2012.
+It lists 249 official short names and code elements. Note: the data reflects a point-in-time snapshot and may not include the most recent ISO 3166/MA updates.
 
 ## License
 
@@ -20,7 +20,7 @@ Nevertheless, it should be noted that this material is ultimately sourced from
 ISO and their rights and licensing policy is somewhat unclear. As this is a
 short, simple database of facts there is a strong argument that no rights can
 subsist in this collection. However, ISO state on [their
-site](http://www.iso.org/iso/home/standards/country_codes.htm): 
+site](https://www.iso.org/iso-3166-country-codes.html): 
 
 > ISO makes the list of alpha-2 country codes available for internal use and
 > non-commercial purposes free of charge. 

--- a/datapackage.yml
+++ b/datapackage.yml
@@ -3,7 +3,7 @@ title: List of all countries with their 2 digit codes (ISO 3166-1)
 description: ISO 3166-1-alpha-2 English country names and code elements. This list states the country names (official short names in English) in alphabetical order as given in ISO 3166-1 and the corresponding ISO 3166-1-alpha-2 code elements.
 sources:
   - name: ISO
-    path: 'https://www.iso.org/iso-3166-country-codes.html'
+    path: 'http://www.iso.org/iso/home/standards/country_codes.html'
     title: ISO
 licenses:
   - name: ODC-PDDL-1.0

--- a/datapackage.yml
+++ b/datapackage.yml
@@ -3,7 +3,7 @@ title: List of all countries with their 2 digit codes (ISO 3166-1)
 description: ISO 3166-1-alpha-2 English country names and code elements. This list states the country names (official short names in English) in alphabetical order as given in ISO 3166-1 and the corresponding ISO 3166-1-alpha-2 code elements.
 sources:
   - name: ISO
-    path: 'http://www.iso.org/iso/home/standards/country_codes.html'
+    path: 'https://www.iso.org/iso-3166-country-codes.html'
     title: ISO
 licenses:
   - name: ODC-PDDL-1.0
@@ -19,9 +19,10 @@ resources:
           description: Country Name
           type: string
         - name: Code
-          description: ISO 2-digit code from ISO 3166-alpha-2
+          description: ISO 2-letter code from ISO 3166-1-alpha-2
           type: string
-    primaryKey: Code
+      primaryKey:
+        - Code
 collection: logistics-data
 has_premium: true
 has_solutions:


### PR DESCRIPTION
- Move \`primaryKey\` from resource level into \`schema\` (as an array) in \`datapackage.yml\`, per Frictionless Data spec
- Fix \`Code\` field description in \`datapackage.yml\`: change \"2-digit\" to \"2-letter\" (ISO 3166-1-alpha-2 codes are alphabetic letters, not digits)
- Correct row count in \`README.md\` from 250 to 249 (actual data rows excluding header)