### PR TITLE
Improve metadata and update data to current ISO 3166-1 (May 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ is effected by the ISO 3166/MA.
 
 It lists 249 official short names and code elements as of May 2026.
 
-**Data note:** `Western Sahara` appears as `Western Sahara*` in the ISO source. The asterisk is carried through as-is; it reflects the territory's indeterminate status in the ISO 3166-1 standard.
+**Data note:** `Western Sahara` appears as `Western Sahara*` in the ISO source. The asterisk denotes a provisional name.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ ISO 3166-1-alpha-2 English country names and code elements. This list states
 the country names (official short names in English) in alphabetical order as
 given in [ISO 3166-1][] and the corresponding ISO 3166-1-alpha-2 code elements.
 
-[ISO 3166-1]: http://www.iso.org/iso/home/standards/country_codes.htm
+[ISO 3166-1]: https://www.iso.org/obp/ui/#search/code/
 
 This list is updated whenever a change to the official code list in ISO 3166-1
 is effected by the ISO 3166/MA.
 
-It lists 249 official short names and code elements as of Dec 2012.
+It lists 249 official short names and code elements as of May 2026.
+
+**Data note:** `Western Sahara` appears as `Western Sahara*` in the ISO source. The asterisk is carried through as-is; it reflects the territory's indeterminate status in the ISO 3166-1 standard.
 
 ## License
 
@@ -20,7 +22,7 @@ Nevertheless, it should be noted that this material is ultimately sourced from
 ISO and their rights and licensing policy is somewhat unclear. As this is a
 short, simple database of facts there is a strong argument that no rights can
 subsist in this collection. However, ISO state on [their
-site](http://www.iso.org/iso/home/standards/country_codes.htm): 
+site](https://www.iso.org/obp/ui/#search/code/): 
 
 > ISO makes the list of alpha-2 country codes available for internal use and
 > non-commercial purposes free of charge. 

--- a/data.csv
+++ b/data.csv
@@ -1,6 +1,5 @@
 Name,Code
 Afghanistan,AF
-Åland Islands,AX
 Albania,AL
 Algeria,DZ
 American Samoa,AS
@@ -15,7 +14,7 @@ Aruba,AW
 Australia,AU
 Austria,AT
 Azerbaijan,AZ
-Bahamas,BS
+Bahamas (The),BS
 Bahrain,BH
 Bangladesh,BD
 Barbados,BB
@@ -25,61 +24,62 @@ Belize,BZ
 Benin,BJ
 Bermuda,BM
 Bhutan,BT
-"Bolivia, Plurinational State of",BO
+Bolivia (Plurinational State of),BO
 "Bonaire, Sint Eustatius and Saba",BQ
 Bosnia and Herzegovina,BA
 Botswana,BW
 Bouvet Island,BV
 Brazil,BR
-British Indian Ocean Territory,IO
+British Indian Ocean Territory (the),IO
 Brunei Darussalam,BN
 Bulgaria,BG
 Burkina Faso,BF
 Burundi,BI
+Cabo Verde,CV
 Cambodia,KH
 Cameroon,CM
 Canada,CA
-Cape Verde,CV
-Cayman Islands,KY
-Central African Republic,CF
+Cayman Islands (the),KY
+Central African Republic (the),CF
 Chad,TD
 Chile,CL
 China,CN
 Christmas Island,CX
-Cocos (Keeling) Islands,CC
+Cocos (Keeling) Islands (the),CC
 Colombia,CO
-Comoros,KM
-Congo,CG
-"Congo, the Democratic Republic of the",CD
-Cook Islands,CK
+Comoros (the),KM
+Congo (the Democratic Republic of the),CD
+Congo (the),CG
+Cook Islands (the),CK
 Costa Rica,CR
-Côte d'Ivoire,CI
 Croatia,HR
 Cuba,CU
 Curaçao,CW
 Cyprus,CY
-Czech Republic,CZ
+Czechia,CZ
+Côte d'Ivoire,CI
 Denmark,DK
 Djibouti,DJ
 Dominica,DM
-Dominican Republic,DO
+Dominican Republic (the),DO
 Ecuador,EC
 Egypt,EG
 El Salvador,SV
 Equatorial Guinea,GQ
 Eritrea,ER
 Estonia,EE
+Eswatini,SZ
 Ethiopia,ET
-Falkland Islands (Malvinas),FK
-Faroe Islands,FO
+Falkland Islands (the) [Malvinas],FK
+Faroe Islands (the),FO
 Fiji,FJ
 Finland,FI
 France,FR
 French Guiana,GF
 French Polynesia,PF
-French Southern Territories,TF
+French Southern Territories (the),TF
 Gabon,GA
-Gambia,GM
+Gambia (the),GM
 Georgia,GE
 Germany,DE
 Ghana,GH
@@ -96,14 +96,14 @@ Guinea-Bissau,GW
 Guyana,GY
 Haiti,HT
 Heard Island and McDonald Islands,HM
-Holy See (Vatican City State),VA
+Holy See (the),VA
 Honduras,HN
 Hong Kong,HK
 Hungary,HU
 Iceland,IS
 India,IN
 Indonesia,ID
-"Iran, Islamic Republic of",IR
+Iran (Islamic Republic of),IR
 Iraq,IQ
 Ireland,IE
 Isle of Man,IM
@@ -116,11 +116,11 @@ Jordan,JO
 Kazakhstan,KZ
 Kenya,KE
 Kiribati,KI
-"Korea, Democratic People's Republic of",KP
-"Korea, Republic of",KR
+Korea (the Democratic People's Republic of),KP
+Korea (the Republic of),KR
 Kuwait,KW
 Kyrgyzstan,KG
-Lao People's Democratic Republic,LA
+Lao People's Democratic Republic (the),LA
 Latvia,LV
 Lebanon,LB
 Lesotho,LS
@@ -130,21 +130,20 @@ Liechtenstein,LI
 Lithuania,LT
 Luxembourg,LU
 Macao,MO
-"Macedonia, the Former Yugoslav Republic of",MK
 Madagascar,MG
 Malawi,MW
 Malaysia,MY
 Maldives,MV
 Mali,ML
 Malta,MT
-Marshall Islands,MH
+Marshall Islands (the),MH
 Martinique,MQ
 Mauritania,MR
 Mauritius,MU
 Mayotte,YT
 Mexico,MX
-"Micronesia, Federated States of",FM
-"Moldova, Republic of",MD
+Micronesia (Federated States of),FM
+Moldova (the Republic of),MD
 Monaco,MC
 Mongolia,MN
 Montenegro,ME
@@ -155,15 +154,16 @@ Myanmar,MM
 Namibia,NA
 Nauru,NR
 Nepal,NP
-Netherlands,NL
+Netherlands (Kingdom of the),NL
 New Caledonia,NC
 New Zealand,NZ
 Nicaragua,NI
-Niger,NE
+Niger (the),NE
 Nigeria,NG
 Niue,NU
 Norfolk Island,NF
-Northern Mariana Islands,MP
+North Macedonia,MK
+Northern Mariana Islands (the),MP
 Norway,NO
 Oman,OM
 Pakistan,PK
@@ -173,16 +173,16 @@ Panama,PA
 Papua New Guinea,PG
 Paraguay,PY
 Peru,PE
-Philippines,PH
+Philippines (the),PH
 Pitcairn,PN
 Poland,PL
 Portugal,PT
 Puerto Rico,PR
 Qatar,QA
-Réunion,RE
 Romania,RO
-Russian Federation,RU
+Russian Federation (the),RU
 Rwanda,RW
+Réunion,RE
 Saint Barthélemy,BL
 "Saint Helena, Ascension and Tristan da Cunha",SH
 Saint Kitts and Nevis,KN
@@ -209,16 +209,15 @@ South Georgia and the South Sandwich Islands,GS
 South Sudan,SS
 Spain,ES
 Sri Lanka,LK
-Sudan,SD
+Sudan (the),SD
 Suriname,SR
 Svalbard and Jan Mayen,SJ
-Eswatini,SZ
 Sweden,SE
 Switzerland,CH
-Syrian Arab Republic,SY
-"Taiwan, Province of China",TW
+Syrian Arab Republic (the),SY
+Taiwan (Province of China),TW
 Tajikistan,TJ
-"Tanzania, United Republic of",TZ
+"Tanzania, the United Republic of",TZ
 Thailand,TH
 Timor-Leste,TL
 Togo,TG
@@ -226,25 +225,26 @@ Tokelau,TK
 Tonga,TO
 Trinidad and Tobago,TT
 Tunisia,TN
-Turkey,TR
 Turkmenistan,TM
-Turks and Caicos Islands,TC
+Turks and Caicos Islands (the),TC
 Tuvalu,TV
+Türkiye,TR
 Uganda,UG
 Ukraine,UA
-United Arab Emirates,AE
-United Kingdom,GB
-United States,US
-United States Minor Outlying Islands,UM
+United Arab Emirates (the),AE
+United Kingdom of Great Britain and Northern Ireland (the),GB
+United States Minor Outlying Islands (the),UM
+United States of America (the),US
 Uruguay,UY
 Uzbekistan,UZ
 Vanuatu,VU
-"Venezuela, Bolivarian Republic of",VE
+Venezuela (Bolivarian Republic of),VE
 Viet Nam,VN
-"Virgin Islands, British",VG
-"Virgin Islands, U.S.",VI
+Virgin Islands (British),VG
+Virgin Islands (U.S.),VI
 Wallis and Futuna,WF
-Western Sahara,EH
+Western Sahara*,EH
 Yemen,YE
 Zambia,ZM
 Zimbabwe,ZW
+Åland Islands,AX

--- a/datapackage.yml
+++ b/datapackage.yml
@@ -2,17 +2,17 @@ name: country-list
 title: List of all countries with their 2 digit codes (ISO 3166-1)
 description: ISO 3166-1-alpha-2 English country names and code elements. This list states the country names (official short names in English) in alphabetical order as given in ISO 3166-1 and the corresponding ISO 3166-1-alpha-2 code elements.
 sources:
-  - name: ISO
-    path: 'http://www.iso.org/iso/home/standards/country_codes.html'
-    title: ISO
+  - name: ISO 3166 Maintenance Agency
+    path: 'https://www.iso.org/obp/ui/#search/code/'
+    title: ISO Online Browsing Platform (OBP) — ISO 3166-1
 licenses:
   - name: ODC-PDDL-1.0
-    path: 'http://opendatacommons.org/licenses/pddl/'
+    path: 'https://opendatacommons.org/licenses/pddl/'
     title: Open Data Commons Public Domain Dedication and License v1.0
 resources:
   - path: data.csv
     name: data
-    description: List of all countries with their official short names in English and corresponding ISO 3166-1 alpha-2 two-letter country codes.
+    description: List of all countries with their official short names in English and corresponding ISO 3166-1 alpha-2 two-letter country codes. Note: "Western Sahara" appears as "Western Sahara*" in the ISO source; the asterisk reflects its indeterminate status in the ISO standard.
     schema:
       fields:
         - name: Name

--- a/datapackage.yml
+++ b/datapackage.yml
@@ -12,7 +12,7 @@ licenses:
 resources:
   - path: data.csv
     name: data
-    description: List of all countries with their official short names in English and corresponding ISO 3166-1 alpha-2 two-letter country codes. Note: "Western Sahara" appears as "Western Sahara*" in the ISO source; the asterisk reflects its indeterminate status in the ISO standard.
+    description: List of all countries with their official short names in English and corresponding ISO 3166-1 alpha-2 two-letter country codes. Note: "Western Sahara" appears as "Western Sahara*" in the ISO source; the asterisk denotes a provisional name.
     schema:
       fields:
         - name: Name


### PR DESCRIPTION
Closes #14 
Closes #11

## Changes

- **data.csv**: synced with ISO Online Browsing Platform (May 2026) — includes official name changes (e.g. country renames), formatting updates (parenthetical article style), and sort order correction for Åland Islands
- **datapackage.yml**: fix license path http→https; document Western Sahara* quirk in resource description; update source URL to ISO OBP
- **README.md**: update source URL; bump date to May 2026; add data note explaining the Western Sahara* asterisk

🤖 Generated with [Claude Code](https://claude.com/claude-code)